### PR TITLE
chore: treat package lock as text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+package-lock.json text


### PR DESCRIPTION
## Summary
- ensure `package-lock.json` is always handled as text

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2f852e2988327ab93e997bfba5762