### PR TITLE
Add static params for project pages

### DIFF
--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -1,11 +1,15 @@
-"use client";
-
 import FadeInSection from '../../../components/FadeInSection';
 import { projects } from '../../../src/config';
-import { useParams } from 'next/navigation';
 
-export default function ProjectPage() {
-  const params = useParams<{ slug: string }>();
+export function generateStaticParams() {
+  return projects.map((p) => ({ slug: p.slug }));
+}
+
+export default function ProjectPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
   const project = projects.find((p) => p.slug === params.slug);
   if (!project) {
     return <div className="max-w-5xl mx-auto py-20">Project not found.</div>;


### PR DESCRIPTION
## Summary
- provide `generateStaticParams` for project detail route
- switch project page to receive params without client hooks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a449f349848327b062bd3f6170d7dc