### PR TITLE
feat: add fetch timeout helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A simple, modern portfolio for a software developer built with Next.js and Tailw
 
 The home page showcases experience, projects, education, skills, and contact details with subtle scroll-triggered animations.
 
+## Requirements
+
+- Node.js 18.17.0 or newer (20.x LTS recommended)
+
 ## Development
 
 - `npm ci` – install dependencies

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import FadeInSection from '../../components/FadeInSection';
+import { fetchWithTimeout } from '../../lib/fetchWithTimeout';
 
 export default function ContactPage() {
   const [name, setName] = useState('');
@@ -12,11 +13,15 @@ export default function ContactPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setStatus('');
-    const res = await fetch('/api/contact', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, email, message }),
-    });
+    const res = await fetchWithTimeout(
+      '/api/contact',
+      10000,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, message }),
+      }
+    );
     if (res.ok) {
       setName('');
       setEmail('');

--- a/components/admin/ContactMessagesSection.tsx
+++ b/components/admin/ContactMessagesSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { fetchWithTimeout } from '../../lib/fetchWithTimeout';
 
 interface ContactMessage {
   id: number;
@@ -14,17 +15,21 @@ export default function ContactMessagesSection() {
   const [messages, setMessages] = useState<ContactMessage[]>([]);
 
   useEffect(() => {
-    fetch('/api/contact')
+    fetchWithTimeout('/api/contact', 10000)
       .then((res) => res.json())
       .then(setMessages);
   }, []);
 
   const deleteMessage = async (id: number) => {
-    await fetch('/api/contact', {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id }),
-    });
+    await fetchWithTimeout(
+      '/api/contact',
+      10000,
+      {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id }),
+      }
+    );
     setMessages(messages.filter((m) => m.id !== id));
   };
 

--- a/components/admin/EducationSection.tsx
+++ b/components/admin/EducationSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { fetchWithTimeout } from '../../lib/fetchWithTimeout';
 
 interface EducationForm {
   school: string;
@@ -27,13 +28,13 @@ export default function EducationSection() {
   });
 
   useEffect(() => {
-    fetch('/api/education')
+    fetchWithTimeout('/api/education', 10000)
       .then((res) => res.json())
       .then((data) => setEducation(data));
   }, []);
 
   const addEducation = async () => {
-    const res = await fetch('/api/education', {
+    const res = await fetchWithTimeout('/api/education', 10000, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(form),
@@ -44,7 +45,7 @@ export default function EducationSection() {
   };
 
   const deleteEducation = async (id: string) => {
-    await fetch('/api/education', {
+    await fetchWithTimeout('/api/education', 10000, {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id }),

--- a/components/admin/ExperiencesSection.tsx
+++ b/components/admin/ExperiencesSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { fetchWithTimeout } from '../../lib/fetchWithTimeout';
 
 interface ExperienceForm {
   role: string;
@@ -33,7 +34,7 @@ export default function ExperiencesSection() {
   });
 
   useEffect(() => {
-    fetch('/api/experiences')
+    fetchWithTimeout('/api/experiences', 10000)
       .then((res) => res.json())
       .then((data) => setExperiences(data));
   }, []);
@@ -50,7 +51,7 @@ export default function ExperiencesSection() {
         .map((h) => h.trim())
         .filter(Boolean),
     };
-    const res = await fetch('/api/experiences', {
+    const res = await fetchWithTimeout('/api/experiences', 10000, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
@@ -61,7 +62,7 @@ export default function ExperiencesSection() {
   };
 
   const deleteExperience = async (id: string) => {
-    await fetch('/api/experiences', {
+    await fetchWithTimeout('/api/experiences', 10000, {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id }),

--- a/components/admin/ProjectsSection.tsx
+++ b/components/admin/ProjectsSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { fetchWithTimeout } from '../../lib/fetchWithTimeout';
 
 interface ProjectForm {
   title: string;
@@ -33,7 +34,7 @@ export default function ProjectsSection() {
   });
 
   useEffect(() => {
-    fetch('/api/projects')
+    fetchWithTimeout('/api/projects', 10000)
       .then((res) => res.json())
       .then((data) => setProjects(data));
   }, []);
@@ -47,7 +48,7 @@ export default function ProjectsSection() {
       live: form.live || undefined,
       repo: form.repo || undefined,
     };
-    const res = await fetch('/api/projects', {
+    const res = await fetchWithTimeout('/api/projects', 10000, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
@@ -58,7 +59,7 @@ export default function ProjectsSection() {
   };
 
   const deleteProject = async (id: string) => {
-    await fetch('/api/projects', {
+    await fetchWithTimeout('/api/projects', 10000, {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id }),

--- a/components/admin/SkillsSection.tsx
+++ b/components/admin/SkillsSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { fetchWithTimeout } from '../../lib/fetchWithTimeout';
 
 interface SkillForm {
   group: string;
@@ -18,7 +19,7 @@ export default function SkillsSection() {
   const [form, setForm] = useState<SkillForm>({ group: '', items: '' });
 
   useEffect(() => {
-    fetch('/api/skills')
+    fetchWithTimeout('/api/skills', 10000)
       .then((res) => res.json())
       .then((data) => setSkills(data));
   }, []);
@@ -31,7 +32,7 @@ export default function SkillsSection() {
         .map((i) => i.trim())
         .filter(Boolean),
     };
-    const res = await fetch('/api/skills', {
+    const res = await fetchWithTimeout('/api/skills', 10000, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
@@ -42,7 +43,7 @@ export default function SkillsSection() {
   };
 
   const deleteSkill = async (id: string) => {
-    await fetch('/api/skills', {
+    await fetchWithTimeout('/api/skills', 10000, {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id }),

--- a/components/admin/TestimonialsSection.tsx
+++ b/components/admin/TestimonialsSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { fetchWithTimeout } from '../../lib/fetchWithTimeout';
 
 interface TestimonialForm {
   author: string;
@@ -18,13 +19,13 @@ export default function TestimonialsSection() {
   const [form, setForm] = useState<TestimonialForm>({ author: '', quote: '' });
 
   useEffect(() => {
-    fetch('/api/testimonials')
+    fetchWithTimeout('/api/testimonials', 10000)
       .then((res) => res.json())
       .then((data) => setTestimonials(data));
   }, []);
 
   const addTestimonial = async () => {
-    const res = await fetch('/api/testimonials', {
+    const res = await fetchWithTimeout('/api/testimonials', 10000, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(form),
@@ -35,7 +36,7 @@ export default function TestimonialsSection() {
   };
 
   const deleteTestimonial = async (id: string) => {
-    await fetch('/api/testimonials', {
+    await fetchWithTimeout('/api/testimonials', 10000, {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id }),

--- a/lib/fetchWithTimeout.ts
+++ b/lib/fetchWithTimeout.ts
@@ -1,0 +1,9 @@
+export async function fetchWithTimeout(url: string, ms = 10000, init?: RequestInit) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ms);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   },
   "license": "ISC",
   "type": "commonjs",
+  "engines": {
+    "node": ">=18.17.0"
+  },
   "dependencies": {
     "@prisma/client": "^6.14.0",
     "bcryptjs": "^3.0.2",


### PR DESCRIPTION
## Summary
- add reusable fetchWithTimeout helper
- safeguard API calls with timeouts across pages and admin components

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a57ff7168c8327b629ea127db68210