### PR TITLE
feat: integrate NextAuth authentication

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -27,6 +27,20 @@ const handler = NextAuth({
     }),
   ],
   session: { strategy: 'jwt' },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.role = (user as any).role;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        (session.user as any).role = token.role as string;
+      }
+      return session;
+    },
+  },
   secret,
 });
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import FadeInSection from '../../components/FadeInSection';
 import { useAuth } from '../../components/AuthProvider';
@@ -12,25 +12,10 @@ export default function LoginPage() {
   const router = useRouter();
   const { login } = useAuth();
 
-  useEffect(() => {
-    const stored = localStorage.getItem('users');
-    if (!stored) {
-      localStorage.setItem(
-        'users',
-        JSON.stringify([
-          {
-            email: 'admin@example.com',
-            password: 'admin123',
-            role: 'admin',
-          },
-        ])
-      );
-    }
-  }, []);
-
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (login(email, password)) {
+    const ok = await login(email, password);
+    if (ok) {
       router.push('/');
     } else {
       setError('Invalid credentials');

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -1,67 +1,52 @@
 'use client';
 
-import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
-
-interface User {
-  email: string;
-  role: 'admin' | 'user';
-}
+import { ReactNode, createContext, useContext } from 'react';
+import { SessionProvider, useSession, signIn, signOut } from 'next-auth/react';
 
 interface AuthContextValue {
   isAuthenticated: boolean;
   isAdmin: boolean;
-  login: (email: string, password: string) => boolean;
-  logout: () => void;
+  login: (email: string, password: string) => Promise<boolean>;
+  logout: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue>({
   isAuthenticated: false,
   isAdmin: false,
-  login: () => false,
-  logout: () => {},
+  login: async () => false,
+  logout: async () => {},
 });
 
-export function AuthProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<User | null>(null);
+function AuthContextProvider({ children }: { children: ReactNode }) {
+  const { data: session } = useSession();
+  const isAuthenticated = !!session;
+  const isAdmin = session?.user?.role === 'admin';
 
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem('user');
-      if (stored) {
-        setUser(JSON.parse(stored));
-      }
-    }
-  }, []);
-
-  const login = (email: string, password: string) => {
-    const usersRaw = localStorage.getItem('users');
-    const users: Array<{ email: string; password: string; role: 'admin' | 'user' }> = usersRaw
-      ? JSON.parse(usersRaw)
-      : [];
-    const found = users.find((u) => u.email === email && u.password === password);
-    if (found) {
-      const authUser = { email: found.email, role: found.role } as const;
-      setUser(authUser);
-      localStorage.setItem('user', JSON.stringify(authUser));
-      localStorage.setItem('isAuthenticated', 'true');
-      return true;
-    }
-    return false;
+  const login = async (email: string, password: string) => {
+    const res = await signIn('credentials', {
+      email,
+      password,
+      redirect: false,
+    });
+    return !!res && res.ok && !res.error;
   };
 
-  const logout = () => {
-    setUser(null);
-    localStorage.removeItem('user');
-    localStorage.removeItem('isAuthenticated');
+  const logout = async () => {
+    await signOut({ redirect: false });
   };
-
-  const isAuthenticated = !!user;
-  const isAdmin = user?.role === 'admin';
 
   return (
     <AuthContext.Provider value={{ isAuthenticated, isAdmin, login, logout }}>
       {children}
     </AuthContext.Provider>
+  );
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  return (
+    <SessionProvider>
+      <AuthContextProvider>{children}</AuthContextProvider>
+    </SessionProvider>
   );
 }
 

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -65,8 +65,8 @@ export default function NavBar() {
           ) : (
             <li>
               <button
-                onClick={() => {
-                  logout();
+                onClick={async () => {
+                  await logout();
                   router.push('/');
                 }}
                 className="text-gray-700 dark:text-gray-200 hover:text-blue-600 dark:hover:text-blue-400 transition-colors transition-transform hover:scale-105"

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,0 +1,16 @@
+import NextAuth, { DefaultSession } from 'next-auth';
+import { JWT } from 'next-auth/jwt';
+
+declare module 'next-auth' {
+  interface Session {
+    user?: {
+      role?: 'admin' | 'user';
+    } & DefaultSession['user'];
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    role?: 'admin' | 'user';
+  }
+}


### PR DESCRIPTION
## Summary
- replace localStorage auth with NextAuth session context
- expose user role in JWT/session and provide login/logout helpers
- refactor login and navbar to use async signIn/signOut
- add type declarations for NextAuth session role

## Testing
- `npm test` *(fails: Missing script "test")*
- `NEXTAUTH_SECRET=secret DATABASE_URL=mysql://user:pass@localhost:3306/db npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a84fe996fc832788f5b6b796447543